### PR TITLE
Makes installing into Ubuntu focal painless

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}
 # Filesystem
          ,reiserfsprogs
          ,reiser4progs
-         ,btrfs-tools
+         ,btrfs-tools | btrfs-prog
          ,xfsprogs
          ,xfsdump
          ,ntfs-3g

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}
 # Filesystem
          ,reiserfsprogs
          ,reiser4progs
-         ,btrfs-tools | btrfs-prog
+         ,btrfs-tools | btrfs-progs
          ,xfsprogs
          ,xfsdump
          ,ntfs-3g


### PR DESCRIPTION
For Ubuntu Focal, btrfs-tools is renamed to btrfs-progs