### PR TITLE
Replace deprecated QtWebKit with QtWebEngine

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -73,7 +73,7 @@ You will find the needed Debian Jessie packages in the following list.
 util-linux (from essential) for the lsblk command.
 
 PYTHON_DBUS_PACKAGES="python3-gi python3-dbus"
-PYTHON_PACKAGES="python-pyqt5 python-pyqt5.qtwebkit"
+PYTHON_PACKAGES="python-pyqt5 python-pyqt5.qtwebengine"
 RAID_PACKAGES="dmraid"
 LVM_PACKAGES="lvm2"
 CRYPTSETUP_PACKAGES="cryptsetup \

--- a/bin/rescapp
+++ b/bin/rescapp
@@ -24,7 +24,7 @@ import time
 import linecache
 import datetime
 import errno
-from PyQt5 import QtGui, QtCore, QtWebKit, QtWidgets, QtWebKitWidgets
+from PyQt5 import QtGui, QtCore, QtWidgets, QtWebEngineWidgets
 from functools import partial
 from enum import Enum, IntEnum
 
@@ -524,7 +524,7 @@ class MainWindow(QtWidgets.QWidget):
         self.help_btn.setToolTip(help_support_option.getDescription())
         self.help_btn.setIcon(QtGui.QIcon(support_icon_path))
 
-        self.wb = QtWebKitWidgets.QWebView()
+        self.wb = QtWebEngineWidgets.QWebEngineView()
         self.wb.load(url)
 
         grid = QtWidgets.QGridLayout()


### PR DESCRIPTION
"QtWebKit got deprecated upstream in Qt 5.5 and [removed in 5.6](http://wiki.qt.io/New_Features_in_Qt_5.6#Removed_Modules)" [1]. Now rescapp will report the following error when run with the newer Qt library:

```text
ImportError: cannot import name 'QtWebEngineWidgets' from 'PyQt5' (/usr/lib/python3/dist-packages/PyQt5/__init__.py)
```

This PR replaces the deprecated `QtWebKit` with `QtWebEngine` thus fixing the problem.

[1] https://stackoverflow.com/questions/37876987/cannot-import-qtwebkitwidgets-in-pyqt5