### PR TITLE
Find the corresponding disk devices of NVMe partitions correctly

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -73,7 +73,7 @@ You will find the needed Debian Jessie packages in the following list.
 util-linux (from essential) for the lsblk command.
 
 PYTHON_DBUS_PACKAGES="python3-gi python3-dbus"
-PYTHON_PACKAGES="python-pyqt5 python-pyqt5.qtwebkit"
+PYTHON_PACKAGES="python-pyqt5 python-pyqt5.qtwebengine"
 RAID_PACKAGES="dmraid"
 LVM_PACKAGES="lvm2"
 CRYPTSETUP_PACKAGES="cryptsetup \

--- a/bin/rescapp
+++ b/bin/rescapp
@@ -24,7 +24,7 @@ import time
 import linecache
 import datetime
 import errno
-from PyQt5 import QtGui, QtCore, QtWebKit, QtWidgets, QtWebKitWidgets
+from PyQt5 import QtGui, QtCore, QtWidgets, QtWebEngineWidgets
 from functools import partial
 from enum import Enum, IntEnum
 
@@ -524,7 +524,7 @@ class MainWindow(QtWidgets.QWidget):
         self.help_btn.setToolTip(help_support_option.getDescription())
         self.help_btn.setIcon(QtGui.QIcon(support_icon_path))
 
-        self.wb = QtWebKitWidgets.QWebView()
+        self.wb = QtWebEngineWidgets.QWebEngineView()
         self.wb.load(url)
 
         grid = QtWidgets.QGridLayout()

--- a/helpers/rescapp-check-partition-disk-type
+++ b/helpers/rescapp-check-partition-disk-type
@@ -20,6 +20,7 @@
 # Returns True (Exit code 0) if Disk type matches the requested one. False (Exit code 2) if it does not match the requested one.
 
 import parted
+import os
 import sys
 import re
 
@@ -28,10 +29,15 @@ if ((len(sys.argv)-1) != 2 ):
         print ('E.g.: ' + sys.argv[0] + ' ' + '/dev/sda2' + ' ' + 'gpt')
         sys.exit(1)
 
+rescapp_binary_path = os.path.dirname(os.path.realpath(__file__))
+
 disktype_partition_str=sys.argv[1]
 disktype_to_check_str=sys.argv[2]
 
-disktype_disk_str=re.sub(r'[0-9]*$', '', disktype_partition_str)
+disktype_disk_str = os.popen(rescapp_binary_path + "/rescapp-find-partition-disk " + disktype_partition_str).readline().strip()
+if disktype_disk_str == "":
+        print ("Can not find the corresponding disk device of " + disktype_partition_str + "!")
+        sys.exit(1)
 
 disktype_device = parted.Device(disktype_disk_str,None)
 disktype_disk = parted.Disk(disktype_device,None)

--- a/helpers/rescapp-check-partition-filesystem
+++ b/helpers/rescapp-check-partition-filesystem
@@ -21,6 +21,7 @@
 
 import parted
 import _ped
+import os
 import sys
 import re
 
@@ -29,10 +30,15 @@ if ((len(sys.argv)-1) != 2 ):
         print ('E.g.: ' + sys.argv[0] + ' ' + '/dev/sda2' + ' ' + 'fat32')
         sys.exit(1)
 
+rescapp_binary_path = os.path.dirname(os.path.realpath(__file__))
+
 filesystem_partition_str=sys.argv[1]
 filesystem_to_check_str=sys.argv[2]
 
-filesystem_disk_str=re.sub(r'[0-9]*$', '', filesystem_partition_str)
+filesystem_disk_str = os.popen(rescapp_binary_path + "/rescapp-find-partition-disk " + filesystem_partition_str).readline().strip()
+if filesystem_disk_str == "":
+        print ("Can not find the corresponding disk device of " + filesystem_partition_str + "!")
+        sys.exit(1)
 
 filesystem_device = parted.Device(filesystem_disk_str,None)
 filesystem_disk = parted.Disk(filesystem_device,None)

--- a/helpers/rescapp-check-partition-flag
+++ b/helpers/rescapp-check-partition-flag
@@ -21,6 +21,7 @@
 
 import parted
 import _ped
+import os
 import sys
 import re
 
@@ -29,10 +30,15 @@ if ((len(sys.argv)-1) != 2 ):
         print ('E.g.: ' + sys.argv[0] + ' ' + '/dev/sda2' + ' ' + 'esp')
         sys.exit(1)
 
+rescapp_binary_path = os.path.dirname(os.path.realpath(__file__))
+
 flag_partition_str=sys.argv[1]
 flag_to_check_str=sys.argv[2]
 
-flag_disk_str=re.sub(r'[0-9]*$', '', flag_partition_str)
+flag_disk_str = os.popen(rescapp_binary_path + "/rescapp-find-partition-disk " + flag_partition_str).readline().strip()
+if flag_disk_str == "":
+        print ("Can not find the corresponding disk device of " + flag_partition_str + "!")
+        sys.exit(1)
 
 flag_device = parted.Device(flag_disk_str,None)
 flag_disk = parted.Disk(flag_device,None)

--- a/helpers/rescapp-find-partition-disk
+++ b/helpers/rescapp-find-partition-disk
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (C) 2022 Jiansheng Qiu
+#
+# Rescapp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rescapp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rescapp.  If not, see <http://www.gnu.org/licenses/>.
+
+# 1st parametre = Partition device
+
+import os
+import stat
+import sys
+import re
+
+if ((len(sys.argv)-1) != 1 ):
+    print ('Usage: ' + sys.argv[0] + ' ' + 'partition_device')
+    print ('E.g.: ' + sys.argv[0] + ' ' + '/dev/nvme0n1p6')
+
+partition_path = sys.argv[1]
+partition_name = os.path.basename(partition_path)
+
+# The longest possible disk name
+longest=re.sub(r'[0-9]*$', '', partition_name)
+
+# Find the block device with the longest name that is the prefix of the longest possible disk name
+for name in os.listdir("/dev/"):
+    path = os.path.join("/dev/", name)
+    if not stat.S_ISBLK(os.stat(path).st_mode):
+        continue
+    if re.match(name + ".*", longest):
+        try:
+            if len(name) >= len(ans):
+                ans = name
+        except NameError:
+            ans = name
+try:
+    print("/dev/" + ans)
+except NameError:
+    # If not found, print nothing.
+    pass

--- a/helpers/rescapp-show-partition-flags
+++ b/helpers/rescapp-show-partition-flags
@@ -22,6 +22,7 @@
 
 import parted
 import _ped
+import os
 import sys
 import re
 
@@ -33,9 +34,14 @@ if ((len(sys.argv)-1) != 1 ):
         print ('E.g.: ' + sys.argv[0] + ' ' + '/dev/sda2')
         sys.exit(1)
 
+rescapp_binary_path = os.path.dirname(os.path.realpath(__file__))
+
 flag_partition_str=sys.argv[1]
 
-flag_disk_str=re.sub(r'[0-9]*$', '', flag_partition_str)
+flag_disk_str = os.popen(rescapp_binary_path + "/rescapp-find-partition-disk " + flag_partition_str).readline().strip()
+if flag_disk_str == "":
+        print ("Can not find the corresponding disk device of " + flag_partition_str + "!")
+        sys.exit(1)
 
 flag_device = parted.Device(flag_disk_str,None)
 flag_disk = parted.Disk(flag_device,None)

--- a/lib/rescapp_lib.sh
+++ b/lib/rescapp_lib.sh
@@ -1215,8 +1215,11 @@ function rtux_UEFI_Check_Is_EFI_System_Partition () {
   local EXIT_VALUE=1 # Error by default
 
   local efi_partition_to_check="$1"
-  local efi_partition_hard_disk="$(echo ${efi_partition_to_check} | sed 's/[0-9]*$//g' 2> /dev/null)"
-  fdisk -lu /dev/${efi_partition_hard_disk} \
+  local efi_partition_hard_disk=$(${RESCAPP_BINARY_PATH}/rescapp-find-partition-disk /dev/${efi_partition_to_check})
+  if "${efi_partition_hard_disk}" == ""; then
+    return 1
+  fi
+  fdisk -lu ${efi_partition_hard_disk} \
        | grep '^/dev/'"${efi_partition_to_check}"'\+[[:space:]]\+' \
        | grep "${FDISK_EFI_SYSTEM_DETECTOR}"'$' \
        > /dev/null 2>&1
@@ -1266,8 +1269,11 @@ function rtux_UEFI_Add_Boot_Entry () {
   # TODO: Check if we are in a UEFI system and warn the user
 
   # Convert EFI PARTITION into EFI disk
-  local TMP_UEFI_EFI_DISK="$(echo ${UEFI_EFI_PARTITION} | sed 's/[0-9]*$//g')" # sda21 -> sda
-  local UEFI_EFI_DISK="/dev/${TMP_UEFI_EFI_DISK}"
+  # /dev/nvme0n1p6 -> /dev/nvme0n1
+  local UEFI_EFI_DISK=$(${RESCAPP_BINARY_PATH}/rescapp-find-partition-disk /dev/${UEFI_EFI_PARTITION})
+  if "${UEFI_EFI_DISK}" == ""; then
+    return 1
+  fi
 
   # Convert EFI PARTITION into partition number
   local UEFI_EFI_PARTITION_NUMBER="$(echo ${UEFI_EFI_PARTITION} | grep -o '[0-9]*$')"
@@ -1528,8 +1534,11 @@ function rtux_UEFI_Fake_Microsoft_Boot_Entry () {
   # Step 2: Define the default level to the default filename and label
 
   # Convert EFI PARTITION into EFI disk
-  local TMP_UEFI_EFI_DISK="$(echo ${UEFI_EFI_PARTITION} | sed 's/[0-9]*$//g')" # sda21 -> sda
-  local UEFI_EFI_DISK="/dev/${TMP_UEFI_EFI_DISK}"
+  # /dev/nvme0n1p6 -> /dev/nvme0n1
+  local UEFI_EFI_DISK=$(${RESCAPP_BINARY_PATH}/rescapp-find-partition-disk /dev/${UEFI_EFI_PARTITION})
+  if "${UEFI_EFI_DISK}" == ""; then
+    return 1
+  fi
 
   # Convert EFI PARTITION into partition number
   local UEFI_EFI_PARTITION_NUMBER="$(echo ${UEFI_EFI_PARTITION} | grep -o '[0-9]*$')"
@@ -1643,8 +1652,11 @@ function rtux_UEFI_Hide_Microsoft_Boot_Entry () {
   # Step 2: Define the default level to the default filename and label
 
   # Convert EFI PARTITION into EFI disk
-  local TMP_UEFI_EFI_DISK="$(echo ${UEFI_EFI_PARTITION} | sed 's/[0-9]*$//g')" # sda21 -> sda
-  local UEFI_EFI_DISK="/dev/${TMP_UEFI_EFI_DISK}"
+  # /dev/nvme0n1p6 -> /dev/nvme0n1
+  local UEFI_EFI_DISK=$(${RESCAPP_BINARY_PATH}/rescapp-find-partition-disk /dev/${UEFI_EFI_PARTITION})
+  if "${UEFI_EFI_DISK}" == ""; then
+    return 1
+  fi
 
   # Convert EFI PARTITION into partition number
   local UEFI_EFI_PARTITION_NUMBER="$(echo ${UEFI_EFI_PARTITION} | grep -o '[0-9]*$')"
@@ -1754,8 +1766,11 @@ function rtux_UEFI_Reinstall_Microsoft_Boot_Entries () {
   # Step 5: Define the default level to the default filename and label
 
   # Convert EFI PARTITION into EFI disk
-  local TMP_UEFI_EFI_DISK="$(echo ${UEFI_EFI_PARTITION} | sed 's/[0-9]*$//g')" # sda21 -> sda
-  local UEFI_EFI_DISK="/dev/${TMP_UEFI_EFI_DISK}"
+  # /dev/nvme0n1p6 -> /dev/nvme0n1
+  local UEFI_EFI_DISK=$(${RESCAPP_BINARY_PATH}/rescapp-find-partition-disk /dev/${UEFI_EFI_PARTITION})
+  if "${UEFI_EFI_DISK}" == ""; then
+    return 1
+  fi
 
   # Convert EFI PARTITION into partition number
   local UEFI_EFI_PARTITION_NUMBER="$(echo ${UEFI_EFI_PARTITION} | grep -o '[0-9]*$')"


### PR DESCRIPTION
This PR fixes #67.

Currently, the path of the corresponding disk device of a partition is calculated by removing the trailing digits from the path of the partition device. This works fine for partitions such as `/dev/sda21`. However, for NVMe partitions, the paths are similar to `/dev/nvme0n1p6`, and simply removing the trailing digits produces `/dev/nvme0n1p`, which is not the corresponding disk device, i.e., `/dev/nvme0n1`.

This PR fixes this. For example, to find the corresponding disk device of the partition `/dev/nvme0n1p6`, this PR first removes the trailing digits from the path and obtains `/dev/nvme0n1p`, which is the longest possible disk name. Then this PR finds the block device with the longest name that is a prefix of the longest possible disk name. For example, `/dev/nvme0n1` and `/dev/nvme0` are all prefixes of `/dev/nvme0n1p`, but `/dev/nvme0n1` is the longest, so this PR choose `/dev/nvme0n1` as the corresponding disk device. In this way, the corresponding disk devices of both NVMe partitions and the partitions in the style of `/dev/sda21` can all be found correctly.