### PR TITLE
Update rescatux web page link

### DIFF
--- a/bin/rescapp
+++ b/bin/rescapp
@@ -957,7 +957,7 @@ class SelftestWindow(QtWidgets.QWidget):
         self.detailsGroup.setTitle("Details")
         self.detailsGroup.setLayout(self.verticalLayout)
 
-        self.bottomLabel = QtWidgets.QLabel("<p>For more troubleshooting tips please refer to <a href=\"https://www.rescatux.org\">https://www.rescatux.org</a> or ask in the chat.</p><p>Selftest log file will be found at: " + self.selftest_log_file + ". You will be able to share it thanks to the 'Share log' option." )
+        self.bottomLabel = QtWidgets.QLabel("<p>For more troubleshooting tips please refer to <a href=\"https://www.supergrubdisk.org/rescatux\">https://www.supergrubdisk.org/rescatux</a> or ask in the chat.</p><p>Selftest log file will be found at: " + self.selftest_log_file + ". You will be able to share it thanks to the 'Share log' option." )
         self.bottomLabel.setWordWrap(True)
         self.bottomLabel.setOpenExternalLinks(True)
         self.bottomLabel.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)

--- a/lib/rescapp_lib.sh
+++ b/lib/rescapp_lib.sh
@@ -1788,7 +1788,7 @@ function rtux_Dbus_End () {
 
 # Rescatux lib main variables
 
-RESCATUX_URL="https://www.rescatux.org/"
+RESCATUX_URL="https://www.supergrubdisk.org/rescatux/"
 RESCATUX_IRC_URL="ircs://irc.libera.chat:6697/rescatux"
 RESCATUX_PASTEBIN_URL="https://paste.debian.net"
 RESC_USER_IRC_PREFIX="resc_"

--- a/plugins/share_log_forum/run
+++ b/plugins/share_log_forum/run
@@ -65,7 +65,7 @@ if [ "x${SELECTED_FILE}" != "x" ] ; then
 
   # Header
   cat << __EOF >> ${RANDOM_SHARE_FORUM_FILE}
-This is a semi-automated message generated from [url="https://www.rescatux.org"]Rescatux live cd[/url].
+This is a semi-automated message generated from [url="https://www.supergrubdisk.org/rescatux"]Rescatux live cd[/url].
 __EOF
 
 


### PR DESCRIPTION
The domain https://www.rescatux.org no redirects to the good one https://www.supergrubdisk.org/rescatux 
I have updated all the links where https://www.rescatux.org is called and set https://www.supergrubdisk.org/rescatux
- README.md
- bin/rescapp
- lib/rescapp_lib.sh
- plugins/share_log_forum/run